### PR TITLE
Improve HTML layout using Bootstrap

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -3,29 +3,10 @@
 <head>
   <meta charset="utf-8" />
   <title>WiFi Spy Dashboard</title>
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
   <style>
     body {
       font-family: Arial, sans-serif;
-      margin: 20px;
-    }
-    h1 {
-      font-size: 1.5rem;
-    }
-    table {
-      border-collapse: collapse;
-      width: 100%;
-      margin-top: 10px;
-    }
-    th, td {
-      border: 1px solid #ccc;
-      padding: 6px 8px;
-      text-align: left;
-    }
-    th {
-      background-color: #f4f4f4;
-    }
-    tbody tr:nth-child(even) {
-      background-color: #fafafa;
     }
   </style>
   <script>
@@ -67,22 +48,27 @@
     });
   </script>
 </head>
-<body>
-  <h1>WiFi Spy Dashboard</h1>
-  <table>
-    <thead>
-      <tr>
-        <th>Ora</th>
-        <th>MAC Fonte</th>
-        <th>BSSID</th>
-        <th>SSID</th>
-        <th>RSSI (dBm)</th>
-        <th>Channel / Frequency</th>
-      </tr>
-    </thead>
-    <tbody id="table-body">
-      <!-- Le righe verranno inserite qui da JavaScript -->
-    </tbody>
-  </table>
+<body class="bg-light">
+      <div class="container py-4">
+      <h1 class="mb-4 text-center">WiFi Spy Dashboard</h1>
+      <div class="table-responsive">
+      <table class="table table-bordered table-striped table-sm">
+      <thead>
+        <tr>
+          <th>Ora</th>
+          <th>MAC Fonte</th>
+          <th>BSSID</th>
+          <th>SSID</th>
+          <th>RSSI (dBm)</th>
+          <th>Channel / Frequency</th>
+        </tr>
+      </thead>
+      <tbody id="table-body">
+        <!-- Le righe verranno inserite qui da JavaScript -->
+      </tbody>
+    </table>
+      </div>
+      </div>
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- modernize dashboard look and feel
- use Bootstrap styles for responsive table and header

## Testing
- `python3 -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_684059003ac4832599ddc1b9af6a8472